### PR TITLE
Bugfix for IsValidationEnabled

### DIFF
--- a/Core/Prism.Validation/IValidatableBindableBase.cs
+++ b/Core/Prism.Validation/IValidatableBindableBase.cs
@@ -2,9 +2,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Prism.Validation
 {

--- a/Core/Prism.Validation/ValidatableBindableBase.cs
+++ b/Core/Prism.Validation/ValidatableBindableBase.cs
@@ -93,7 +93,8 @@ namespace Prism.Validation
         /// </returns>
         public bool ValidateProperties()
         {
-            return _bindableValidator.ValidateProperties();
+            return !_bindableValidator.IsValidationEnabled // don't fail if validation is disabled
+                || _bindableValidator.ValidateProperties();
         }
 
         /// <summary>


### PR DESCRIPTION
Fixed a bug for issue #3 where ValidatableBindableBase.ValidateProperties() did not considered IsValidationEnabled.